### PR TITLE
Add MySQL data directory configuration for XtraBackup

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ MYSQL_HOST=oempro_mysql
 MYSQL_ROOT_PASSWORD=your_root_password
 MYSQL_DATABASE=oempro
 
+# MySQL data directory on HOST (required for XtraBackup)
+# For Octeth Docker: /opt/oempro/_dockerfiles/mysql/data_v8
+MYSQL_DATA_DIR=/opt/oempro/_dockerfiles/mysql/data_v8
+
 # Backup Storage
 BACKUP_DIR=/var/backups/octeth
 
@@ -170,6 +174,8 @@ MYSQL_ROOT_PASSWORD=             # Root password (required)
 MYSQL_DATABASE=oempro            # Database name
 MYSQL_USERNAME=oempro            # MySQL user
 MYSQL_PASSWORD=                  # MySQL password
+MYSQL_DATA_DIR=                  # MySQL data directory on HOST (required)
+                                 # For Octeth: /opt/oempro/_dockerfiles/mysql/data_v8
 ```
 
 #### Backup Storage

--- a/bin/octeth-backup.sh
+++ b/bin/octeth-backup.sh
@@ -237,11 +237,23 @@ perform_backup() {
         log_info "Connecting to MySQL via exposed port: ${mysql_host}:${mysql_port}"
     fi
 
+    # Verify MySQL data directory exists
+    if [ ! -d "${MYSQL_DATA_DIR}" ]; then
+        log_error "MySQL data directory not found: ${MYSQL_DATA_DIR}"
+        log_error "Please set MYSQL_DATA_DIR in config/.env to the host path of MySQL data"
+        log_error "For Octeth: /opt/oempro/_dockerfiles/mysql/data_v8"
+        EXIT_CODE=1
+        return 1
+    fi
+
+    log_info "MySQL data directory: ${MYSQL_DATA_DIR}"
+
     # Run XtraBackup from HOST (not inside container)
     log_info "Running: xtrabackup --backup"
 
     if ${XTRABACKUP_BIN} --backup \
         --target-dir="${temp_backup_dir}" \
+        --datadir="${MYSQL_DATA_DIR}" \
         --host="${mysql_host}" \
         --port="${mysql_port}" \
         --user=root \

--- a/config/.env.example
+++ b/config/.env.example
@@ -25,6 +25,12 @@ MYSQL_DATABASE=oempro
 MYSQL_USERNAME=oempro
 MYSQL_PASSWORD=your_mysql_password_here
 
+# MySQL data directory on HOST (required for XtraBackup)
+# This is the path to MySQL data directory on the host filesystem
+# For Octeth Docker installations, this is typically the volume mount path
+# Example for Octeth: /opt/oempro/_dockerfiles/mysql/data_v8
+MYSQL_DATA_DIR=/opt/oempro/_dockerfiles/mysql/data_v8
+
 # ============================================
 # Backup Storage Settings
 # ============================================


### PR DESCRIPTION
## Problem
XtraBackup was failing with:
```
xtrabackup: Can't change dir to '/var/lib/mysql/' (OS errno 2 - No such file or directory)
[ERROR] cannot my_setwd /var/lib/mysql/
```

This happens because XtraBackup runs on the host and needs direct access to MySQL data files. For Docker installations, the MySQL data is in a volume mount on the host (e.g., `/opt/oempro/_dockerfiles/mysql/data_v8`), not at the default `/var/lib/mysql/` path.

## Solution
- Add `MYSQL_DATA_DIR` configuration variable
- Pass this to XtraBackup using the `--datadir` parameter
- Add validation to ensure the directory exists before backup
- Document the configuration with Octeth-specific examples

## Changes
1. **config/.env.example**: Added `MYSQL_DATA_DIR` with default Octeth path
2. **bin/octeth-backup.sh**: 
   - Added directory existence check
   - Added `--datadir` parameter to XtraBackup command
   - Clear error messages if directory not found
3. **README.md**: Updated configuration sections with data directory examples

## Configuration
Users now need to set in their `config/.env`:
```bash
MYSQL_DATA_DIR=/opt/oempro/_dockerfiles/mysql/data_v8
```

For Octeth installations, this is the standard path. For other setups, users should specify their MySQL volume mount path.

## Testing
Tested on production server with:
- XtraBackup 8.0.35-31
- MySQL 8.0.41 in Docker
- Data directory: `/opt/oempro/_dockerfiles/mysql/data_v8`

## Impact
- Required configuration change for all users (non-breaking, fails with clear error message)
- Enables XtraBackup to access MySQL data files correctly
- Maintains zero-downtime backup operation

Fixes the issue reported in production testing.