### PR TITLE
Add Cloudflare R2 storage support

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -66,8 +66,8 @@ COMPRESSION_LEVEL=6
 # Cloud Storage Settings
 # ============================================
 
-# Cloud storage provider: s3, gcs, or none
-# s3 = Amazon S3, gcs = Google Cloud Storage, none = local only
+# Cloud storage provider: s3, gcs, r2, or none
+# s3 = Amazon S3, gcs = Google Cloud Storage, r2 = Cloudflare R2, none = local only
 CLOUD_STORAGE_PROVIDER=none
 
 # ============================================
@@ -124,6 +124,34 @@ GCS_RCLONE_REMOTE=gcs
 # Google Cloud credentials JSON file path (optional)
 # Leave empty to use default gcloud credentials or service account
 GOOGLE_APPLICATION_CREDENTIALS=
+
+# ============================================
+# Cloudflare R2 Storage Settings
+# ============================================
+
+# R2 bucket name
+R2_BUCKET=my-octeth-backups
+
+# R2 account ID (required, found in Cloudflare dashboard)
+R2_ACCOUNT_ID=your-account-id
+
+# R2 path prefix (optional, no leading/trailing slashes)
+# Example: octeth/production or leave empty for bucket root
+R2_PREFIX=octeth
+
+# R2 storage class (not applicable for R2, included for consistency)
+R2_STORAGE_CLASS=STANDARD
+
+# R2 access credentials (create in Cloudflare R2 dashboard)
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+
+# R2 upload tool: awscli or rclone
+# Note: R2 is S3-compatible, so we use AWS CLI with custom endpoint
+R2_UPLOAD_TOOL=awscli
+
+# rclone remote name (only if using rclone for R2)
+R2_RCLONE_REMOTE=r2
 
 # ============================================
 # Retention Policy Settings


### PR DESCRIPTION
## Summary

Implements Cloudflare R2 as a third cloud storage option alongside S3 and GCS. R2 uses S3-compatible API with custom endpoints, providing zero egress fees and cost-effective storage for backups.

## Changes

- ✅ Add R2 configuration variables to .env.example
- ✅ Implement R2 upload functions in octeth-backup.sh
- ✅ Implement R2 download functions in octeth-restore.sh
- ✅ Implement R2 cleanup functions in octeth-cleanup.sh
- ✅ Add comprehensive R2 documentation to README.md
- ✅ Update CLAUDE.md with implementation details

## Features

- Support for both AWS CLI and rclone as upload tools
- Automatic checksum upload and verification
- Retention policy enforcement for R2 backups
- Full integration with existing backup/restore/cleanup workflows

Resolves #7

🤖 Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/octeth/octeth-backup-tools/tree/claude/issue-7-20251212-0816) | [View job run](https://github.com/octeth/octeth-backup-tools/actions/runs/20160589578