### PR TITLE
Streaming MySQL backups, no-local retention, and binlog capture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md - Octeth MySQL Backup Tool
+# CLAUDE.md - Octeth MySQL + ClickHouse Backup Tool
 
 This file provides comprehensive guidance for AI assistants (Claude, GitHub Copilot, etc.) working with the Octeth Backup Tools codebase.
 
@@ -9,7 +9,9 @@ This file provides comprehensive guidance for AI assistants (Claude, GitHub Copi
 ### Key Features
 - **Zero-Downtime Hot Backups**: Uses Percona XtraBackup for hot backups while MySQL stays online
 - **Smart Retention Policy**: Daily (7 days) + Weekly (4 weeks) + Monthly (6 months)
-- **Dual Storage**: Local filesystem + S3-compatible cloud storage
+- **Streaming Compression**: MySQL backups stream `xbstream` straight into the compressor → `*.xbstream.gz` (no uncompressed staging); ClickHouse tars its backup dir straight into the compressor
+- **Multi-Cloud Storage**: one provider at a time — S3, GCS, R2, or `none`
+- **No-Local Mode**: `KEEP_LOCAL_BACKUP=false` deletes the local copy after a successful cloud upload
 - **Production-Ready**: Comprehensive error handling, logging, and notifications
 - **Fast & Efficient**: 70-80% less CPU usage compared to mysqldump
 - **Parallel Compression**: Supports pigz for faster compression
@@ -52,22 +54,21 @@ octeth-backup-tools/
 **Purpose**: Performs hot backups of MySQL databases using XtraBackup.
 
 **Key Functions**:
-- `check_lock_file()`: Prevents concurrent backup runs (lines 95-110)
-- `check_xtrabackup()`: Verifies XtraBackup installation (lines 112-121)
-- `check_disk_space()`: Validates sufficient disk space, critical for avoiding "No space left on device" errors (lines 123-167)
-- `check_mysql_connection()`: Tests MySQL connectivity (lines 169-178)
-- `determine_backup_type()`: Determines daily/weekly/monthly based on date (lines 201-221)
-- `perform_backup()`: Executes XtraBackup hot backup (lines 227-307)
-- `compress_backup()`: Compresses backup with pigz/gzip (lines 309-338)
-- `upload_to_s3()`: Uploads to S3 storage (lines 344-373)
-- `send_notifications()`: Sends email/webhook notifications (lines 421-488)
+- `check_lock_file()`: Prevents concurrent backup runs
+- `check_xtrabackup()`: Verifies XtraBackup installation
+- `check_disk_space()`: Validates free space in `BACKUP_DIR` against a ~40%-of-DB compressed estimate
+- `check_mysql_connection()`: Tests MySQL connectivity
+- `determine_backup_type()`: Determines daily/weekly/monthly based on date
+- `perform_backup()`: Streams `xtrabackup --stream=xbstream | compressor` → `*.xbstream.gz`, integrity-checks it, writes the `.sha256` (no separate compress function anymore)
+- `upload_to_cloud()` → `upload_to_{s3,gcs,r2}()`: provider dispatch; data upload must succeed (`|| return 1`) before the caller may delete the local copy
+- `send_notifications()`: Sends email/webhook notifications
 
 **Critical Implementation Details**:
-- Uses XtraBackup from the HOST, not inside the container (line 277)
+- Uses XtraBackup from the HOST, not inside the container
 - Requires access to MySQL data directory on host filesystem (MYSQL_DATA_DIR)
-- Calculates required temp space: DB size + 20% + 5GB buffer (lines 150-164)
-- Creates checksums (SHA256) for all backups (lines 328-330)
-- Supports both direct port access and container IP connection (lines 243-261)
+- Streams compressed output directly to `BACKUP_DIR` — no uncompressed temp staging
+- Creates checksums (SHA256) for all backups
+- Connection detection order: exposed port → host-network mode → container IP
 
 **Error Handling**:
 - Comprehensive disk space checks before backup starts
@@ -244,7 +245,9 @@ MYSQL_DATA_DIR=                      # HOST path to MySQL data (CRITICAL)
 
 # Storage
 BACKUP_DIR=/var/backups/octeth       # Local backup location
-TEMP_DIR=/var/backups/octeth/tmp     # Must have DB size + 20% + 5GB free
+TEMP_DIR=/var/backups/octeth/tmp     # Used by RESTORE (extract+prepare); backups no longer stage here
+KEEP_LOCAL_BACKUP=true               # false = delete local copy after successful upload (MySQL + CH)
+MYSQL_LOG_BIN=                       # set if binlogs live outside the datadir (auto --log-bin-index)
 
 # Compression
 COMPRESSION_TOOL=auto                # auto, pigz, or gzip
@@ -283,7 +286,7 @@ WEBHOOK_ENABLED=false
 
 # Advanced
 DOCKER_CMD=docker                    # Use "sudo docker" if needed
-VERIFY_BACKUP=true                   # Runs XtraBackup --prepare
+VERIFY_BACKUP=true                   # Integrity-checks the compressed archive (prepare runs at restore)
 ```
 
 ### Backup Configuration (`backup.conf`)
@@ -393,48 +396,31 @@ Percona XtraBackup:
 - Multi-threaded
 - Hot backup with transaction log consistency
 
-### Backup Process
+### Backup Process (streaming, single pass)
 
-1. **Backup Phase** (lines 277-291 in octeth-backup.sh):
-   ```bash
-   xtrabackup --backup \
-     --target-dir="${temp_backup_dir}" \
-     --datadir="${MYSQL_DATA_DIR}" \
-     --host="${mysql_host}" \
-     --port="${mysql_port}" \
-     --user=root \
-     --password="${MYSQL_ROOT_PASSWORD}" \
-     --parallel=${threads}
-   ```
-   - Copies InnoDB data files
-   - Records transaction log position
-   - No table locks (hot backup)
+`perform_backup()` streams the backup straight into the compressor and writes a single `*.xbstream.gz` — there is **no** uncompressed temp staging dir, **no** separate tar pass, and **no** inline `--prepare`:
 
-2. **Prepare Phase** (lines 294-304):
-   ```bash
-   xtrabackup --prepare --target-dir="${temp_backup_dir}"
-   ```
-   - Applies transaction logs
-   - Makes backup consistent
-   - Required for restore
+```bash
+xtrabackup --backup --datadir="${MYSQL_DATA_DIR}" \
+  --host="${mysql_host}" --port="${mysql_port}" --user=root --password="..." \
+  --parallel=${threads} ${log_bin_opt} ${log_bin_index_opt} --stream=xbstream \
+  ${XTRABACKUP_EXTRA_OPTS} 2>> "${LOG_FILE}" \
+  | ${COMPRESSION_TOOL} -${COMPRESSION_LEVEL} > "${dest_file}"
+```
 
-3. **Compression** (lines 320):
-   ```bash
-   tar -cf - -C "${parent_dir}" "${backup_dirname}" | ${COMPRESSION_TOOL} -${COMPRESSION_LEVEL} > "${dest_file}"
-   ```
-   - Parallel compression with pigz (3-4x faster)
-   - Adjustable compression level (1-9)
+Key points:
+- The artifact is `*.xbstream.gz`, NOT a prepared `*.tar.gz` directory. The script relies on `set -o pipefail` to fail if either xtrabackup or the compressor fails.
+- A streamed backup **cannot be `--prepare`d in place**, so prepare moved to **restore** time. `VERIFY_BACKUP=true` now runs `${COMPRESSION_TOOL} -t` (integrity check), not a prepare.
+- `MYSQL_LOG_BIN` (when set) auto-passes `--log-bin` + derived `--log-bin-index` for binlogs outside the datadir. Empty → both omitted.
+- The connection logic detects exposed port → host-network mode → container IP (in that order). Preserve it when editing.
+
+### No-local-retention invariant
+
+When `KEEP_LOCAL_BACKUP=false`, `main()` deletes the local file after upload. This is only safe because `upload_to_{s3,gcs,r2}` **return non-zero if the data-file upload fails** (`... "$backup_file" ... || return 1`; checksum upload is best-effort). `main()` deletes local only when the upload returned success and the provider isn't `none`. If you edit the upload functions, preserve this or a failed upload could delete the only copy. The same pattern applies in `octeth-ch-backup.sh`.
 
 ### Restore Process
 
-1. **Extract** (line 352 in octeth-restore.sh)
-2. **Stop MySQL** (line 369)
-3. **Safety Backup** (line 400)
-4. **Clear Data Directory** (line 406)
-5. **Copy Restored Data** (line 411)
-6. **Fix Permissions** (line 421)
-7. **Start MySQL** (line 425)
-8. **Verify** (lines 452-454)
+Restore branches on extension: `*.xbstream.gz` → decompress → `xbstream -x` → `xtrabackup --prepare`; legacy `*.tar.gz` → `tar -xzf` (already prepared). Then both converge: stop MySQL → safety-copy the data dir → wipe + replace → `chown 999:999` → start → poll `mysqladmin ping`. Restore extracts the full uncompressed DB into `TEMP_DIR`, so that's where the large disk requirement now lives.
 
 ## Integration with Octeth
 
@@ -597,12 +583,11 @@ Cost optimization:
 
 ### "No space left on device"
 
-**Cause**: TEMP_DIR too small for uncompressed database.
+**Cause**: Backups now stream-compress directly to `BACKUP_DIR` (only the compressed `.xbstream.gz`, ~40% of the DB), so this points at `BACKUP_DIR` running low — not `TEMP_DIR`. (Restore, however, still extracts the full uncompressed DB into `TEMP_DIR`.)
 
 **Solution**:
-1. Set `TEMP_DIR=/var/backups/octeth/tmp` in .env
-2. Ensure disk has DB size + 20% + 5GB free
-3. Clean up old backups: `./bin/octeth-cleanup.sh`
+1. Free space on `BACKUP_DIR`'s disk; lower `RETENTION_*` or set `KEEP_LOCAL_BACKUP=false`
+2. Run `./bin/octeth-cleanup.sh`
 
 ### "XtraBackup not found"
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ A professional, production-ready backup solution for Octeth supporting both **My
 
 - **Zero-Downtime Hot Backups**: MySQL via Percona XtraBackup, ClickHouse via clickhouse-backup
 - **Multi-Database Support**: Independent backup/restore/cleanup for MySQL and ClickHouse
+- **Streaming Compression**: Backups are streamed straight into the compressor and written to disk once, already compressed — no large uncompressed staging copy (MySQL uses `xbstream`)
+- **No-Local Mode**: Optionally delete the local copy right after a successful cloud upload (`KEEP_LOCAL_BACKUP=false`) so the disk never fills up
 - **Smart Retention Policy**: Daily (7 days) + Weekly (4 weeks) + Monthly (6 months)
 - **Cloud Storage**: Local filesystem + AWS S3, Google Cloud Storage, or Cloudflare R2
 - **Production-Ready**: Comprehensive error handling, logging, and notifications
-- **Fast & Efficient**: Physical backups with minimal CPU and zero downtime
 - **Parallel Compression**: Supports pigz for faster compression
-- **Easy Restore**: Simple restore process with checksum verification
-- **Automated Cleanup**: Automatic retention policy enforcement
+- **Easy Restore**: Single command; reads both the new `.xbstream.gz` and legacy `.tar.gz` formats
+- **One-Command Deploy**: `deploy.sh` rsyncs the tool to a server (delta transfer + rollback backup)
 
 ## Why Physical Backups?
 
@@ -290,14 +291,25 @@ CH_LOG_FILE=/var/log/octeth-ch-backup.log # Log file
 
 #### Backup Storage (MySQL)
 ```bash
-BACKUP_DIR=/var/backups/octeth      # Local backup directory
-TEMP_DIR=/var/backups/octeth/tmp    # Temporary directory (CRITICAL: needs DB size + 20% free space)
-                                     # WARNING: Do NOT use /tmp - often too small!
+BACKUP_DIR=/var/backups/octeth      # Where compressed backups are written before upload
+KEEP_LOCAL_BACKUP=true              # false = delete local copy after a successful cloud upload
+                                     # (applies to BOTH MySQL and ClickHouse)
+TEMP_DIR=/var/backups/octeth/tmp    # Used by RESTORE (extract + prepare); avoid /tmp
 MAX_DISK_USAGE=85                   # Maximum disk usage % (abort if exceeded)
 MIN_FREE_SPACE_GB=10                # Minimum free space required
 ```
 
-**IMPORTANT:** `TEMP_DIR` must have enough space for the full uncompressed database backup. The script calculates required space as: Database Size + 20% buffer + 5GB. Using `/tmp` will likely cause "No space left on device" errors for databases larger than a few GB.
+**Disk space:** Backups stream and compress on the fly, so a backup only writes the final compressed `.xbstream.gz` (typically ~40% of the data directory) into `BACKUP_DIR`. With `KEEP_LOCAL_BACKUP=false` it's deleted right after upload, so the disk only holds it transiently. `TEMP_DIR` is now a **restore**-time concern — restore extracts the full uncompressed database there.
+
+#### Binary logs (MySQL, optional)
+```bash
+MYSQL_LOG_BIN=                   # Binlog basename on HOST; set ONLY if binary logging is
+                                 # enabled AND binlogs live outside the data dir.
+                                 # Passed as --log-bin; index auto-derived as <basename>.index.
+MYSQL_LOG_BIN_INDEX=             # Override the derived index path (rarely needed)
+```
+
+If a MySQL backup fails with `cannot open binlog index file`, set `MYSQL_LOG_BIN` to the host binlog basename (e.g. `/opt/oempro/_dockerfiles/mysql/log_v8/mysql-bin`). Leave empty when binary logging is disabled (`skip-log-bin`).
 
 #### Compression
 ```bash
@@ -370,7 +382,7 @@ WEBHOOK_URL=                     # Webhook URL
 
 #### Advanced Settings
 ```bash
-VERIFY_BACKUP=true               # Verify backup after creation
+VERIFY_BACKUP=true               # Integrity-check the compressed archive (prepare runs at restore)
 LOCK_FILE=/tmp/octeth-backup.lock # Lock file path
 LOG_FILE=/var/log/octeth-backup.log # Log file path
 LOG_RETENTION_DAYS=30            # Keep logs for N days
@@ -620,6 +632,23 @@ grep ERROR /var/log/octeth-ch-backup.log
 
 Logs are automatically rotated and cleaned up after 30 days.
 
+## Deployment
+
+`deploy.sh` rsyncs the tool to a server, transferring only changed files and saving any overwritten file to a timestamped backup dir on the server (so a deploy can be rolled back). The live secret config (`config/.env`, `config/backup.conf`) is **excluded by default** so the server's credentials are never clobbered.
+
+```bash
+# Preview (no changes)
+DEPLOY_HOST=my-server ./deploy.sh --dry-run
+
+# Deploy code (leaves server config/.env untouched)
+./deploy.sh --host my-server
+
+# One-off: also push the local config/.env + backup.conf
+./deploy.sh --host my-server --include-env
+```
+
+Host/user/path/port are flags or env vars (`DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_PATH` default `/opt/octeth-backup-tools`, `SSH_PORT`). Because config is excluded by default, set new config keys (e.g. `KEEP_LOCAL_BACKUP`, `MYSQL_LOG_BIN`) directly on the server's `config/.env` after a code-only deploy. It does **not** use `rsync --append` (which would corrupt code files); `--partial` is available for resumable transfers.
+
 ## Cron Setup
 
 The installer creates cron jobs automatically:
@@ -763,52 +792,30 @@ DOCKER_CMD="sudo docker"
 
 ### Backup Fails: "No space left on device"
 
-This is a critical error that occurs when XtraBackup runs out of disk space during backup. This can also cause MySQL to crash or become unresponsive.
+Since backups stream and compress on the fly, only the final compressed file is written (into `BACKUP_DIR`) — there is no large uncompressed staging copy. So this error now points at `BACKUP_DIR` running low, not `TEMP_DIR`.
 
 **Symptoms:**
 ```
 xtrabackup: Error writing file ... (OS errno 28 - No space left on device)
 ```
 
-**Cause:** The `TEMP_DIR` (default: `/tmp/octeth-backup`) doesn't have enough space for the uncompressed database backup.
-
 **Solution:**
 
-1. **Change TEMP_DIR location** (recommended):
+1. **Check space on the backup disk:**
    ```bash
-   # Edit config/.env
-   TEMP_DIR=/var/backups/octeth/tmp  # Use same disk as backups
-   ```
-
-2. **Check space requirements:**
-   ```bash
-   # Check database size
-   du -sh /opt/oempro/_dockerfiles/mysql/data_v8
-
-   # Check available space in temp directory
    df -h /var/backups
-
-   # Rule: TEMP_DIR needs DB size + 20% + 5GB free
-   # Example: 10GB database needs ~17GB free in TEMP_DIR
+   du -sh /opt/oempro/_dockerfiles/mysql/data_v8   # ~40% of this is the compressed backup size
    ```
 
-3. **Clean up temp directory:**
-   ```bash
-   # Remove any stale temp files
-   rm -rf /var/backups/octeth/tmp/*
-   ```
+2. **Free space / tighten retention:** lower `RETENTION_*`, or set `KEEP_LOCAL_BACKUP=false` to keep backups only in the cloud, then run the cleanup script.
 
-4. **If MySQL crashed during backup:**
+3. **If MySQL crashed during backup:**
    ```bash
-   # Restart MySQL container
    docker restart oempro_mysql
-
-   # Verify MySQL is healthy
    docker logs oempro_mysql
-   docker exec oempro_mysql mysql -uroot -p'password' -e "SHOW STATUS LIKE 'Uptime';"
    ```
 
-**Prevention:** Always ensure TEMP_DIR has sufficient space before running backups. The script now checks this automatically and will abort with a clear error if space is insufficient.
+> **Restore** is the operation that now needs a large `TEMP_DIR` — it extracts and prepares the full uncompressed database there. Ensure `TEMP_DIR` has room for the uncompressed DB before restoring.
 
 ### S3 Upload Fails
 
@@ -1207,6 +1214,16 @@ For issues, questions, or contributions:
 - Octeth Support: support@octeth.com
 
 ## Changelog
+
+### v1.2.0
+- **Streaming MySQL backups**: `xtrabackup --stream=xbstream` piped straight into the compressor → `*.xbstream.gz` written once; no uncompressed temp staging and no separate tar pass
+- **`MYSQL_LOG_BIN` / `MYSQL_LOG_BIN_INDEX`**: capture binary logs when they live outside the data directory (auto-derived `--log-bin-index`)
+- **`VERIFY_BACKUP`** now integrity-checks the compressed archive; the prepare/apply-logs step moved to restore time
+- **`KEEP_LOCAL_BACKUP`** (MySQL + ClickHouse): delete the local copy after a successful cloud upload; uploads return failure on data-upload errors so the last copy is never deleted
+- **ClickHouse**: archive straight from the `clickhouse-backup` output (tar → compressor), removing the extra `CH_TEMP_DIR` copy
+- **Restore** reads both `.xbstream.gz` and legacy `.tar.gz`; cleanup matches both
+- **`deploy.sh`**: rsync delta deploy with on-server rollback backups
+- Slack-compatible webhook payloads (added a `text` field)
 
 ### v1.1.0 (2026-03-16)
 - ClickHouse backup support using clickhouse-backup (Altinity)

--- a/bin/octeth-backup.sh
+++ b/bin/octeth-backup.sh
@@ -121,15 +121,14 @@ check_xtrabackup() {
 }
 
 check_disk_space() {
-    local backup_dir_parent=$(dirname "${BACKUP_DIR}")
-
-    # Create backup and temp directories if they don't exist
+    # Streaming backups compress on the fly, so only the final compressed
+    # artifact lands on disk in BACKUP_DIR (and, with KEEP_LOCAL_BACKUP=false,
+    # only transiently until it is uploaded). No uncompressed staging copy is
+    # written anymore, so we only validate the backup destination.
     mkdir -p "${BACKUP_DIR}"
-    mkdir -p "${TEMP_DIR}"
 
-    # Check disk usage for backup directory
-    local disk_usage=$(df -h "${backup_dir_parent}" | awk 'NR==2 {print $5}' | sed 's/%//')
-    local free_space_gb=$(df -BG "${backup_dir_parent}" | awk 'NR==2 {print $4}' | sed 's/G//')
+    local disk_usage=$(df -h "${BACKUP_DIR}" | awk 'NR==2 {print $5}' | sed 's/%//')
+    local free_space_gb=$(df -BG "${BACKUP_DIR}" | awk 'NR==2 {print $4}' | sed 's/G//')
 
     if [ "$disk_usage" -gt "$MAX_DISK_USAGE" ]; then
         log_error "Backup directory disk usage is ${disk_usage}% (threshold: ${MAX_DISK_USAGE}%)"
@@ -141,29 +140,22 @@ check_disk_space() {
         exit 1
     fi
 
-    log_info "Backup directory disk check passed: ${free_space_gb}GB free, ${disk_usage}% used"
-
-    # Check disk space for temp directory (critical for XtraBackup)
-    local temp_disk_usage=$(df -h "${TEMP_DIR}" | awk 'NR==2 {print $5}' | sed 's/%//')
-    local temp_free_space_gb=$(df -BG "${TEMP_DIR}" | awk 'NR==2 {print $4}' | sed 's/G//')
-
-    # Estimate required space (database size + 20% buffer)
+    # Rough sanity check: a compressed xbstream is typically ~40% of the data
+    # directory size. Abort early if the destination clearly cannot hold it.
     if [ -d "${MYSQL_DATA_DIR}" ]; then
         local db_size_gb=$(du -sb "${MYSQL_DATA_DIR}" 2>/dev/null | awk '{print int($1/1024/1024/1024)}')
-        local required_space=$((db_size_gb + db_size_gb / 5 + 5))  # DB size + 20% + 5GB buffer
+        local est_compressed=$((db_size_gb * 2 / 5 + 1))  # ~40% of DB + 1GB buffer
 
-        log_info "Database size: ~${db_size_gb}GB, temp directory has ${temp_free_space_gb}GB free"
+        log_info "Database size: ~${db_size_gb}GB, estimated compressed backup: ~${est_compressed}GB, ${free_space_gb}GB free"
 
-        if [ "$temp_free_space_gb" -lt "$required_space" ]; then
-            log_error "Insufficient space in temp directory!"
-            log_error "Required: ~${required_space}GB, Available: ${temp_free_space_gb}GB"
-            log_error "Please increase TEMP_DIR space or set TEMP_DIR to a location with more space"
-            log_error "Recommended: TEMP_DIR=/var/backups/octeth/tmp (same disk as backups)"
+        if [ "$free_space_gb" -lt "$est_compressed" ]; then
+            log_error "Insufficient space for compressed backup in ${BACKUP_DIR}"
+            log_error "Estimated required: ~${est_compressed}GB, Available: ${free_space_gb}GB"
             exit 1
         fi
     fi
 
-    log_info "Temp directory disk check passed: ${temp_free_space_gb}GB free, ${temp_disk_usage}% used"
+    log_info "Backup directory disk check passed: ${free_space_gb}GB free, ${disk_usage}% used"
 }
 
 check_mysql_connection() {
@@ -225,11 +217,12 @@ determine_backup_type() {
 # ============================================
 
 perform_backup() {
-    log_info "Starting XtraBackup hot backup (zero downtime)"
+    log_info "Starting XtraBackup streaming hot backup (zero downtime)"
 
-    # Create temporary directory for backup
-    mkdir -p "${TEMP_DIR}"
-    local temp_backup_dir="${TEMP_DIR}/${BACKUP_NAME}"
+    # Final compressed artifact. We stream xbstream straight into the compressor,
+    # so the backup is written to disk exactly once, already compressed. There is
+    # no uncompressed staging copy and no separate tar/compress pass.
+    local dest_file="${BACKUP_DEST}/${BACKUP_NAME}.xbstream.gz"
 
     # Determine number of parallel threads
     local threads="${PARALLEL_THREADS}"
@@ -268,7 +261,7 @@ perform_backup() {
     else
         log_info "Connecting to MySQL via exposed port: ${mysql_host}:${mysql_port}"
     fi
-    
+
     # Verify MySQL data directory exists
     if [ ! -d "${MYSQL_DATA_DIR}" ]; then
         log_error "MySQL data directory not found: ${MYSQL_DATA_DIR}"
@@ -280,70 +273,76 @@ perform_backup() {
 
     log_info "MySQL data directory: ${MYSQL_DATA_DIR}"
 
-    # Run XtraBackup from HOST (not inside container)
-    log_info "Running: xtrabackup --backup"
+    # Binary logs often live outside the data directory (e.g. a sibling log_v8/).
+    # When MYSQL_LOG_BIN is set, XtraBackup is told the binlog basename so it can
+    # capture the binlog and its coordinates; without it the backup can fail.
+    #
+    # The binlog *index* file is read from a SEPARATE path (the server's
+    # log_bin_index variable), which a containerized MySQL reports as its
+    # in-container path (e.g. /var/log/mysql/mysql-bin.index) — a path that does
+    # not exist on the host where xtrabackup runs. We therefore also pass
+    # --log-bin-index. By convention the index sits next to the binlogs as
+    # <basename>.index, so we derive it from MYSQL_LOG_BIN unless MYSQL_LOG_BIN_INDEX
+    # is set explicitly. Leave MYSQL_LOG_BIN empty if binary logging is disabled.
+    local log_bin_opt=""
+    local log_bin_index_opt=""
+    if [ -n "${MYSQL_LOG_BIN:-}" ]; then
+        log_bin_opt="--log-bin=${MYSQL_LOG_BIN}"
+        local log_bin_index="${MYSQL_LOG_BIN_INDEX:-${MYSQL_LOG_BIN}.index}"
+        log_bin_index_opt="--log-bin-index=${log_bin_index}"
+        log_info "Including binary logs: ${MYSQL_LOG_BIN} (index: ${log_bin_index})"
+    fi
 
-    if ${XTRABACKUP_BIN} --backup \
-        --target-dir="${temp_backup_dir}" \
+    # Run XtraBackup from HOST (not inside container) and stream the xbstream
+    # output directly into the compressor. pipefail (set -o pipefail) makes the
+    # whole pipeline fail if either xtrabackup or the compressor fails.
+    log_info "Streaming backup to: ${dest_file} (compressed with ${COMPRESSION_TOOL})"
+
+    if ionice -c 3 nice -n 19 ${XTRABACKUP_BIN} --backup \
         --datadir="${MYSQL_DATA_DIR}" \
         --host="${mysql_host}" \
         --port="${mysql_port}" \
         --user=root \
         --password="${MYSQL_ROOT_PASSWORD}" \
         --parallel=${threads} \
-        ${XTRABACKUP_EXTRA_OPTS} >> "${LOG_FILE}" 2>&1; then
-        log_success "XtraBackup completed successfully"
+        ${log_bin_opt} \
+        ${log_bin_index_opt} \
+        --stream=xbstream \
+        ${XTRABACKUP_EXTRA_OPTS:-} 2>> "${LOG_FILE}" \
+        | ${COMPRESSION_TOOL} -${COMPRESSION_LEVEL} > "${dest_file}"; then
+        log_success "XtraBackup stream completed"
     else
-        log_error "XtraBackup failed"
+        log_error "XtraBackup streaming backup failed"
+        rm -f "${dest_file}"
         EXIT_CODE=1
         return 1
     fi
 
-    # Prepare the backup (make it consistent)
+    # A streamed backup cannot be prepared in place; the prepare step now happens
+    # at restore time (octeth-restore.sh). Here we instead validate that the
+    # compressed archive is intact (not truncated/corrupt), which is cheap.
     if [ "${VERIFY_BACKUP}" = "true" ]; then
-        log_info "Preparing backup (applying transaction logs)"
+        log_info "Verifying compressed backup integrity"
 
-        if ${XTRABACKUP_BIN} --prepare --target-dir="${temp_backup_dir}" >> "${LOG_FILE}" 2>&1; then
-            log_success "Backup prepared successfully (ready for restore)"
+        if ${COMPRESSION_TOOL} -t "${dest_file}" 2>> "${LOG_FILE}"; then
+            log_success "Backup integrity check passed"
         else
-            log_error "Backup prepare failed"
+            log_error "Backup integrity check failed (corrupt or truncated archive)"
+            rm -f "${dest_file}"
             EXIT_CODE=1
             return 1
         fi
     fi
 
-    echo "${temp_backup_dir}"
-}
+    # Size + checksum
+    local size=$(du -h "${dest_file}" | cut -f1)
+    log_info "Backup size: ${size}"
 
-compress_backup() {
-    local source_dir="$1"
-    local dest_file="${BACKUP_DEST}/${BACKUP_NAME}.tar.gz"
+    local checksum=$(sha256sum "${dest_file}" | cut -d' ' -f1)
+    echo "${checksum}  ${BACKUP_NAME}.xbstream.gz" > "${dest_file}.sha256"
+    log_info "Checksum: ${checksum}"
 
-    log_info "Compressing backup with ${COMPRESSION_TOOL}"
-
-    # Get parent directory and backup directory name
-    local parent_dir=$(dirname "${source_dir}")
-    local backup_dirname=$(basename "${source_dir}")
-
-    # Compress backup using tar and pigz/gzip
-    if tar -cf - -C "${parent_dir}" "${backup_dirname}" | ${COMPRESSION_TOOL} -${COMPRESSION_LEVEL} > "${dest_file}"; then
-        log_success "Backup compressed: ${dest_file}"
-
-        # Calculate size
-        local size=$(du -h "${dest_file}" | cut -f1)
-        log_info "Backup size: ${size}"
-
-        # Create checksum
-        local checksum=$(sha256sum "${dest_file}" | cut -d' ' -f1)
-        echo "${checksum}  ${BACKUP_NAME}.tar.gz" > "${dest_file}.sha256"
-        log_info "Checksum: ${checksum}"
-
-        echo "${dest_file}"
-    else
-        log_error "Compression failed"
-        EXIT_CODE=1
-        return 1
-    fi
+    echo "${dest_file}"
 }
 
 # ============================================
@@ -379,23 +378,27 @@ upload_to_s3() {
 
     log_info "Uploading to S3: s3://${S3_BUCKET}/${S3_PREFIX}/${s3_path}"
 
+    # The data upload MUST succeed; if it fails, return failure now so the caller
+    # never deletes the local copy (KEEP_LOCAL_BACKUP). Checksum upload is best-effort.
     if [ "${S3_UPLOAD_TOOL}" = "awscli" ]; then
-        upload_s3_with_aws_cli "$backup_file" "$s3_path"
+        upload_s3_with_aws_cli "$backup_file" "$s3_path" || return 1
     elif [ "${S3_UPLOAD_TOOL}" = "rclone" ]; then
-        upload_s3_with_rclone "$backup_file" "$s3_path"
+        upload_s3_with_rclone "$backup_file" "$s3_path" || return 1
     else
         log_error "Unknown S3 upload tool: ${S3_UPLOAD_TOOL}"
         return 1
     fi
 
-    # Upload checksum file
+    # Upload checksum file (best-effort)
     if [ -f "$checksum_file" ]; then
         if [ "${S3_UPLOAD_TOOL}" = "awscli" ]; then
-            upload_s3_with_aws_cli "$checksum_file" "${s3_path}.sha256"
+            upload_s3_with_aws_cli "$checksum_file" "${s3_path}.sha256" || log_warn "Checksum upload failed"
         else
-            upload_s3_with_rclone "$checksum_file" "${s3_path}.sha256"
+            upload_s3_with_rclone "$checksum_file" "${s3_path}.sha256" || log_warn "Checksum upload failed"
         fi
     fi
+
+    return 0
 }
 
 upload_s3_with_aws_cli() {
@@ -451,23 +454,27 @@ upload_to_gcs() {
 
     log_info "Uploading to GCS: gs://${GCS_BUCKET}/${GCS_PREFIX}/${gcs_path}"
 
+    # The data upload MUST succeed; if it fails, return failure now so the caller
+    # never deletes the local copy (KEEP_LOCAL_BACKUP). Checksum upload is best-effort.
     if [ "${GCS_UPLOAD_TOOL}" = "gsutil" ]; then
-        upload_gcs_with_gsutil "$backup_file" "$gcs_path"
+        upload_gcs_with_gsutil "$backup_file" "$gcs_path" || return 1
     elif [ "${GCS_UPLOAD_TOOL}" = "rclone" ]; then
-        upload_gcs_with_rclone "$backup_file" "$gcs_path"
+        upload_gcs_with_rclone "$backup_file" "$gcs_path" || return 1
     else
         log_error "Unknown GCS upload tool: ${GCS_UPLOAD_TOOL}"
         return 1
     fi
 
-    # Upload checksum file
+    # Upload checksum file (best-effort)
     if [ -f "$checksum_file" ]; then
         if [ "${GCS_UPLOAD_TOOL}" = "gsutil" ]; then
-            upload_gcs_with_gsutil "$checksum_file" "${gcs_path}.sha256"
+            upload_gcs_with_gsutil "$checksum_file" "${gcs_path}.sha256" || log_warn "Checksum upload failed"
         else
-            upload_gcs_with_rclone "$checksum_file" "${gcs_path}.sha256"
+            upload_gcs_with_rclone "$checksum_file" "${gcs_path}.sha256" || log_warn "Checksum upload failed"
         fi
     fi
+
+    return 0
 }
 
 upload_gcs_with_gsutil() {
@@ -538,23 +545,27 @@ upload_to_r2() {
 
     log_info "Uploading to R2: https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${R2_BUCKET}/${R2_PREFIX}/${r2_path}"
 
+    # The data upload MUST succeed; if it fails, return failure now so the caller
+    # never deletes the local copy (KEEP_LOCAL_BACKUP). Checksum upload is best-effort.
     if [ "${R2_UPLOAD_TOOL}" = "awscli" ]; then
-        upload_r2_with_aws_cli "$backup_file" "$r2_path"
+        upload_r2_with_aws_cli "$backup_file" "$r2_path" || return 1
     elif [ "${R2_UPLOAD_TOOL}" = "rclone" ]; then
-        upload_r2_with_rclone "$backup_file" "$r2_path"
+        upload_r2_with_rclone "$backup_file" "$r2_path" || return 1
     else
         log_error "Unknown R2 upload tool: ${R2_UPLOAD_TOOL}"
         return 1
     fi
 
-    # Upload checksum file
+    # Upload checksum file (best-effort)
     if [ -f "$checksum_file" ]; then
         if [ "${R2_UPLOAD_TOOL}" = "awscli" ]; then
-            upload_r2_with_aws_cli "$checksum_file" "${r2_path}.sha256"
+            upload_r2_with_aws_cli "$checksum_file" "${r2_path}.sha256" || log_warn "Checksum upload failed"
         else
-            upload_r2_with_rclone "$checksum_file" "${r2_path}.sha256"
+            upload_r2_with_rclone "$checksum_file" "${r2_path}.sha256" || log_warn "Checksum upload failed"
         fi
     fi
+
+    return 0
 }
 
 upload_r2_with_aws_cli() {
@@ -704,6 +715,8 @@ send_webhook() {
 # ============================================
 
 main() {
+    ulimit -n 65536
+
     log_info "=========================================="
     log_info "Octeth MySQL Backup Started"
     log_info "=========================================="
@@ -718,24 +731,21 @@ main() {
     # Determine backup type
     determine_backup_type
 
-    # Perform backup
-    local temp_backup_dir
-    if ! temp_backup_dir=$(perform_backup); then
-        send_notifications "failure"
-        exit 1
-    fi
-
-    # Compress backup
+    # Perform streaming backup (xbstream -> compressor -> single compressed file)
     local backup_file
-    if ! backup_file=$(compress_backup "$temp_backup_dir"); then
+    if ! backup_file=$(perform_backup); then
         send_notifications "failure"
         exit 1
     fi
 
     # Upload to cloud storage
-    upload_to_cloud "$backup_file" || log_warn "Cloud upload failed (continuing anyway)"
+    local upload_ok=true
+    if ! upload_to_cloud "$backup_file"; then
+        upload_ok=false
+        log_warn "Cloud upload failed (local copy retained for retry)"
+    fi
 
-    # Success
+    # Success banner + notification (while the file still exists, so size is known)
     local duration=$(($(date +%s) - BACKUP_START_TIME))
     log_success "=========================================="
     log_success "Backup completed in ${duration}s"
@@ -743,6 +753,20 @@ main() {
     log_success "=========================================="
 
     send_notifications "success" "$backup_file"
+
+    # Remove the local copy when we don't keep local backups. Only delete once the
+    # backup is safely in the cloud — never delete the last remaining copy.
+    local keep_local="${KEEP_LOCAL_BACKUP:-true}"
+    if [ "${keep_local}" = "false" ]; then
+        if [ "${CLOUD_STORAGE_PROVIDER}" = "none" ]; then
+            log_warn "KEEP_LOCAL_BACKUP=false but CLOUD_STORAGE_PROVIDER=none; keeping local backup (nowhere else to store it)"
+        elif [ "${upload_ok}" = true ]; then
+            log_info "Removing local backup (KEEP_LOCAL_BACKUP=false); retained in ${CLOUD_STORAGE_PROVIDER}"
+            rm -f "${backup_file}" "${backup_file}.sha256"
+        else
+            log_warn "Keeping local backup because the cloud upload failed"
+        fi
+    fi
 
     exit 0
 }

--- a/bin/octeth-ch-backup.sh
+++ b/bin/octeth-ch-backup.sh
@@ -247,15 +247,14 @@ check_compression_tool() {
 }
 
 check_disk_space() {
-    local backup_dir_parent=$(dirname "${CH_BACKUP_DIR}")
-
-    # Create backup and temp directories if they don't exist
+    # The compressed backup is written to CH_BACKUP_DIR. clickhouse-backup's local
+    # "create" uses hardlinks to the data parts (near-zero extra space), and we tar
+    # straight into the compressor, so we no longer stage a second uncompressed
+    # copy. Validate the backup destination.
     mkdir -p "${CH_BACKUP_DIR}"
-    mkdir -p "${CH_TEMP_DIR}"
 
-    # Check disk usage for backup directory
-    local disk_usage=$(df -h "${backup_dir_parent}" | awk 'NR==2 {print $5}' | sed 's/%//')
-    local free_space_gb=$(df -BG "${backup_dir_parent}" | awk 'NR==2 {print $4}' | sed 's/G//')
+    local disk_usage=$(df -h "${CH_BACKUP_DIR}" | awk 'NR==2 {print $5}' | sed 's/%//')
+    local free_space_gb=$(df -BG "${CH_BACKUP_DIR}" | awk 'NR==2 {print $4}' | sed 's/G//')
 
     if [ "$disk_usage" -gt "$MAX_DISK_USAGE" ]; then
         log_error "Backup directory disk usage is ${disk_usage}% (threshold: ${MAX_DISK_USAGE}%)"
@@ -267,30 +266,23 @@ check_disk_space() {
         exit 1
     fi
 
-    log_info "Backup directory disk check passed: ${free_space_gb}GB free, ${disk_usage}% used"
-
-    # Check temp directory space
-    local temp_disk_usage=$(df -h "${CH_TEMP_DIR}" | awk 'NR==2 {print $5}' | sed 's/%//')
-    local temp_free_space_gb=$(df -BG "${CH_TEMP_DIR}" | awk 'NR==2 {print $4}' | sed 's/G//')
-
-    # Estimate required space from ClickHouse database size
+    # Rough sanity check: estimate compressed size ~40% of the ClickHouse db size.
     local db_size_bytes=$(${DOCKER_CMD} exec ${CH_HOST} clickhouse-client \
         --user="${CH_USER}" ${CH_PASSWORD:+--password="${CH_PASSWORD}"} \
         --query="SELECT coalesce(sum(bytes_on_disk), 0) FROM system.parts WHERE active AND database='${CH_DATABASE}'" 2>/dev/null || echo "0")
 
     local db_size_gb=$((db_size_bytes / 1024 / 1024 / 1024))
-    local required_space=$((db_size_gb + db_size_gb / 5 + 5))  # DB size + 20% + 5GB buffer
+    local est_compressed=$((db_size_gb * 2 / 5 + 1))  # ~40% of DB + 1GB buffer
 
-    log_info "Database size: ~${db_size_gb}GB, temp directory has ${temp_free_space_gb}GB free"
+    log_info "Database size: ~${db_size_gb}GB, estimated compressed backup: ~${est_compressed}GB, ${free_space_gb}GB free"
 
-    if [ "$temp_free_space_gb" -lt "$required_space" ]; then
-        log_error "Insufficient space in temp directory!"
-        log_error "Required: ~${required_space}GB, Available: ${temp_free_space_gb}GB"
-        log_error "Please increase CH_TEMP_DIR space or set CH_TEMP_DIR to a location with more space"
+    if [ "$free_space_gb" -lt "$est_compressed" ]; then
+        log_error "Insufficient space for compressed backup in ${CH_BACKUP_DIR}"
+        log_error "Estimated required: ~${est_compressed}GB, Available: ${free_space_gb}GB"
         exit 1
     fi
 
-    log_info "Temp directory disk check passed: ${temp_free_space_gb}GB free, ${temp_disk_usage}% used"
+    log_info "Backup directory disk check passed: ${free_space_gb}GB free, ${disk_usage}% used"
 }
 
 check_clickhouse_connection() {
@@ -339,8 +331,7 @@ determine_backup_type() {
 perform_backup() {
     log_info "Starting ClickHouse hot backup (zero downtime)"
 
-    # Create temporary directory
-    mkdir -p "${CH_TEMP_DIR}"
+    local dest_file="${BACKUP_DEST}/${BACKUP_NAME}.tar.gz"
 
     # Run clickhouse-backup create
     log_info "Running: clickhouse-backup create ${BACKUP_NAME}"
@@ -355,63 +346,48 @@ perform_backup() {
         return 1
     fi
 
-    # Copy backup to temp directory
-    local temp_backup_dir="${CH_TEMP_DIR}/${BACKUP_NAME}"
+    # Compress the freshly created backup directly into the destination, streaming
+    # tar -> compressor. This avoids staging a second full copy in CH_TEMP_DIR.
+    # pipefail makes the pipeline fail if either tar or the compressor fails.
+    log_info "Compressing backup with ${COMPRESSION_TOOL}"
 
     if [ -n "${CH_DATA_DIR:-}" ] && [ -d "${CH_DATA_DIR}/backup/${BACKUP_NAME}" ]; then
-        # Direct access via mounted volume (works for both sidecar and internal modes)
-        log_info "Copying backup from data directory: ${CH_DATA_DIR}/backup/${BACKUP_NAME}"
-        cp -a "${CH_DATA_DIR}/backup/${BACKUP_NAME}" "${temp_backup_dir}"
+        # Backup directory is reachable on the host via the mounted volume
+        log_info "Archiving from data directory: ${CH_DATA_DIR}/backup/${BACKUP_NAME}"
+        if ! tar -cf - -C "${CH_DATA_DIR}/backup" "${BACKUP_NAME}" \
+            | ${COMPRESSION_TOOL} -${COMPRESSION_LEVEL} > "${dest_file}"; then
+            log_error "Compression failed"
+            rm -f "${dest_file}"
+            EXIT_CODE=1
+            return 1
+        fi
     else
-        # Fallback: Use docker cp from the ClickHouse container (internal mode only)
-        log_info "Copying backup from container via docker cp"
-        ${DOCKER_CMD} cp "${CH_HOST}:/var/lib/clickhouse/backup/${BACKUP_NAME}" "${temp_backup_dir}"
+        # Internal mode without host volume access: stream tar out of the container
+        log_info "Archiving from container via docker exec tar"
+        if ! ${DOCKER_CMD} exec ${CH_HOST} tar -cf - -C /var/lib/clickhouse/backup "${BACKUP_NAME}" \
+            | ${COMPRESSION_TOOL} -${COMPRESSION_LEVEL} > "${dest_file}"; then
+            log_error "Compression failed"
+            rm -f "${dest_file}"
+            EXIT_CODE=1
+            return 1
+        fi
     fi
 
-    if [ ! -d "${temp_backup_dir}" ]; then
-        log_error "Failed to copy backup to temp directory"
-        EXIT_CODE=1
-        return 1
-    fi
+    log_success "Backup compressed: ${dest_file}"
 
-    log_success "Backup copied to host: ${temp_backup_dir}"
+    # Size + checksum
+    local size=$(du -h "${dest_file}" | cut -f1)
+    log_info "Backup size: ${size}"
 
-    # Clean up raw backup from the data directory
+    local checksum=$(sha256sum "${dest_file}" | cut -d' ' -f1)
+    echo "${checksum}  ${BACKUP_NAME}.tar.gz" > "${dest_file}.sha256"
+    log_info "Checksum: ${checksum}"
+
+    # Clean up the raw backup from clickhouse-backup local storage
     run_clickhouse_backup delete local "${BACKUP_NAME}" >> "${CH_LOG_FILE}" 2>&1 || \
         log_warn "Failed to clean up raw backup (non-fatal)"
 
-    echo "${temp_backup_dir}"
-}
-
-compress_backup() {
-    local source_dir="$1"
-    local dest_file="${BACKUP_DEST}/${BACKUP_NAME}.tar.gz"
-
-    log_info "Compressing backup with ${COMPRESSION_TOOL}"
-
-    # Get parent directory and backup directory name
-    local parent_dir=$(dirname "${source_dir}")
-    local backup_dirname=$(basename "${source_dir}")
-
-    # Compress backup using tar and pigz/gzip
-    if tar -cf - -C "${parent_dir}" "${backup_dirname}" | ${COMPRESSION_TOOL} -${COMPRESSION_LEVEL} > "${dest_file}"; then
-        log_success "Backup compressed: ${dest_file}"
-
-        # Calculate size
-        local size=$(du -h "${dest_file}" | cut -f1)
-        log_info "Backup size: ${size}"
-
-        # Create checksum
-        local checksum=$(sha256sum "${dest_file}" | cut -d' ' -f1)
-        echo "${checksum}  ${BACKUP_NAME}.tar.gz" > "${dest_file}.sha256"
-        log_info "Checksum: ${checksum}"
-
-        echo "${dest_file}"
-    else
-        log_error "Compression failed"
-        EXIT_CODE=1
-        return 1
-    fi
+    echo "${dest_file}"
 }
 
 # ============================================
@@ -447,23 +423,27 @@ upload_to_s3() {
 
     log_info "Uploading to S3: s3://${S3_BUCKET}/${S3_PREFIX}/${s3_path}"
 
+    # The data upload MUST succeed; if it fails, return failure now so the caller
+    # never deletes the local copy (KEEP_LOCAL_BACKUP). Checksum upload is best-effort.
     if [ "${S3_UPLOAD_TOOL}" = "awscli" ]; then
-        upload_s3_with_aws_cli "$backup_file" "$s3_path"
+        upload_s3_with_aws_cli "$backup_file" "$s3_path" || return 1
     elif [ "${S3_UPLOAD_TOOL}" = "rclone" ]; then
-        upload_s3_with_rclone "$backup_file" "$s3_path"
+        upload_s3_with_rclone "$backup_file" "$s3_path" || return 1
     else
         log_error "Unknown S3 upload tool: ${S3_UPLOAD_TOOL}"
         return 1
     fi
 
-    # Upload checksum file
+    # Upload checksum file (best-effort)
     if [ -f "$checksum_file" ]; then
         if [ "${S3_UPLOAD_TOOL}" = "awscli" ]; then
-            upload_s3_with_aws_cli "$checksum_file" "${s3_path}.sha256"
+            upload_s3_with_aws_cli "$checksum_file" "${s3_path}.sha256" || log_warn "Checksum upload failed"
         else
-            upload_s3_with_rclone "$checksum_file" "${s3_path}.sha256"
+            upload_s3_with_rclone "$checksum_file" "${s3_path}.sha256" || log_warn "Checksum upload failed"
         fi
     fi
+
+    return 0
 }
 
 upload_s3_with_aws_cli() {
@@ -519,23 +499,27 @@ upload_to_gcs() {
 
     log_info "Uploading to GCS: gs://${GCS_BUCKET}/${GCS_PREFIX}/${gcs_path}"
 
+    # The data upload MUST succeed; if it fails, return failure now so the caller
+    # never deletes the local copy (KEEP_LOCAL_BACKUP). Checksum upload is best-effort.
     if [ "${GCS_UPLOAD_TOOL}" = "gsutil" ]; then
-        upload_gcs_with_gsutil "$backup_file" "$gcs_path"
+        upload_gcs_with_gsutil "$backup_file" "$gcs_path" || return 1
     elif [ "${GCS_UPLOAD_TOOL}" = "rclone" ]; then
-        upload_gcs_with_rclone "$backup_file" "$gcs_path"
+        upload_gcs_with_rclone "$backup_file" "$gcs_path" || return 1
     else
         log_error "Unknown GCS upload tool: ${GCS_UPLOAD_TOOL}"
         return 1
     fi
 
-    # Upload checksum file
+    # Upload checksum file (best-effort)
     if [ -f "$checksum_file" ]; then
         if [ "${GCS_UPLOAD_TOOL}" = "gsutil" ]; then
-            upload_gcs_with_gsutil "$checksum_file" "${gcs_path}.sha256"
+            upload_gcs_with_gsutil "$checksum_file" "${gcs_path}.sha256" || log_warn "Checksum upload failed"
         else
-            upload_gcs_with_rclone "$checksum_file" "${gcs_path}.sha256"
+            upload_gcs_with_rclone "$checksum_file" "${gcs_path}.sha256" || log_warn "Checksum upload failed"
         fi
     fi
+
+    return 0
 }
 
 upload_gcs_with_gsutil() {
@@ -603,23 +587,27 @@ upload_to_r2() {
 
     log_info "Uploading to R2: ${R2_BUCKET}/${R2_PREFIX}/${r2_path}"
 
+    # The data upload MUST succeed; if it fails, return failure now so the caller
+    # never deletes the local copy (KEEP_LOCAL_BACKUP). Checksum upload is best-effort.
     if [ "${R2_UPLOAD_TOOL}" = "awscli" ]; then
-        upload_r2_with_aws_cli "$backup_file" "$r2_path"
+        upload_r2_with_aws_cli "$backup_file" "$r2_path" || return 1
     elif [ "${R2_UPLOAD_TOOL}" = "rclone" ]; then
-        upload_r2_with_rclone "$backup_file" "$r2_path"
+        upload_r2_with_rclone "$backup_file" "$r2_path" || return 1
     else
         log_error "Unknown R2 upload tool: ${R2_UPLOAD_TOOL}"
         return 1
     fi
 
-    # Upload checksum file
+    # Upload checksum file (best-effort)
     if [ -f "$checksum_file" ]; then
         if [ "${R2_UPLOAD_TOOL}" = "awscli" ]; then
-            upload_r2_with_aws_cli "$checksum_file" "${r2_path}.sha256"
+            upload_r2_with_aws_cli "$checksum_file" "${r2_path}.sha256" || log_warn "Checksum upload failed"
         else
-            upload_r2_with_rclone "$checksum_file" "${r2_path}.sha256"
+            upload_r2_with_rclone "$checksum_file" "${r2_path}.sha256" || log_warn "Checksum upload failed"
         fi
     fi
+
+    return 0
 }
 
 upload_r2_with_aws_cli() {
@@ -704,7 +692,7 @@ Backup Details:
     fi
 
     if [ "${WEBHOOK_ENABLED}" = "true" ]; then
-        local payload='{"status":"success","message":"Octeth ClickHouse backup completed","timestamp":"%TIMESTAMP%","backup_size":"%SIZE%"}'
+        local payload='{"text":"✅ Octeth ClickHouse backup completed (%SIZE%) at %TIMESTAMP%","status":"success","backup_size":"%SIZE%","timestamp":"%TIMESTAMP%"}'
         payload="${payload//%TIMESTAMP%/$(date -Iseconds)}"
         payload="${payload//%SIZE%/${size}}"
         send_webhook "$payload"
@@ -730,7 +718,7 @@ Please check the log file: ${CH_LOG_FILE}
     fi
 
     if [ "${WEBHOOK_ENABLED}" = "true" ]; then
-        local payload='{"status":"failure","message":"Octeth ClickHouse backup failed","timestamp":"%TIMESTAMP%","error":"%ERROR%"}'
+        local payload='{"text":"🚨 Octeth ClickHouse backup FAILED at %TIMESTAMP%: %ERROR%","status":"failure","error":"%ERROR%","timestamp":"%TIMESTAMP%"}'
         payload="${payload//%TIMESTAMP%/$(date -Iseconds)}"
         payload="${payload//%ERROR%/${ERROR_LOG}}"
         send_webhook "$payload"
@@ -781,24 +769,21 @@ main() {
     # Determine backup type
     determine_backup_type
 
-    # Perform backup
-    local temp_backup_dir
-    if ! temp_backup_dir=$(perform_backup); then
-        send_notifications "failure"
-        exit 1
-    fi
-
-    # Compress backup
+    # Perform backup (clickhouse-backup create -> tar|compressor -> .tar.gz)
     local backup_file
-    if ! backup_file=$(compress_backup "$temp_backup_dir"); then
+    if ! backup_file=$(perform_backup); then
         send_notifications "failure"
         exit 1
     fi
 
     # Upload to cloud storage
-    upload_to_cloud "$backup_file" || log_warn "Cloud upload failed (continuing anyway)"
+    local upload_ok=true
+    if ! upload_to_cloud "$backup_file"; then
+        upload_ok=false
+        log_warn "Cloud upload failed (local copy retained for retry)"
+    fi
 
-    # Success
+    # Success banner + notification (while the file still exists, so size is known)
     local duration=$(($(date +%s) - BACKUP_START_TIME))
     log_success "=========================================="
     log_success "ClickHouse backup completed in ${duration}s"
@@ -806,6 +791,20 @@ main() {
     log_success "=========================================="
 
     send_notifications "success" "$backup_file"
+
+    # Remove the local copy when we don't keep local backups. Only delete once the
+    # backup is safely in the cloud — never delete the last remaining copy.
+    local keep_local="${KEEP_LOCAL_BACKUP:-true}"
+    if [ "${keep_local}" = "false" ]; then
+        if [ "${CLOUD_STORAGE_PROVIDER}" = "none" ]; then
+            log_warn "KEEP_LOCAL_BACKUP=false but CLOUD_STORAGE_PROVIDER=none; keeping local backup (nowhere else to store it)"
+        elif [ "${upload_ok}" = true ]; then
+            log_info "Removing local backup (KEEP_LOCAL_BACKUP=false); retained in ${CLOUD_STORAGE_PROVIDER}"
+            rm -f "${backup_file}" "${backup_file}.sha256"
+        else
+            log_warn "Keeping local backup because the cloud upload failed"
+        fi
+    fi
 
     exit 0
 }

--- a/bin/octeth-cleanup.sh
+++ b/bin/octeth-cleanup.sh
@@ -101,7 +101,7 @@ cleanup_directory() {
     local backup_files=()
     while IFS= read -r -d '' file; do
         backup_files+=("$file")
-    done < <(find "$dir" -maxdepth 1 -name "*.tar.gz" -type f -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | tr '\n' '\0')
+    done < <(find "$dir" -maxdepth 1 \( -name "*.tar.gz" -o -name "*.xbstream.gz" \) -type f -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | tr '\n' '\0')
     local total_backups=${#backup_files[@]}
 
     log_info "Found ${total_backups} ${backup_type} backup(s)"
@@ -198,7 +198,7 @@ cleanup_s3_with_aws_cli() {
 
         # List all backups in S3 for this type
         local s3_backups=($(aws s3 ls "s3://${S3_BUCKET}/${s3_prefix}" --region "${S3_REGION}" 2>/dev/null | \
-            grep "\.tar\.gz$" | sort -r | awk '{print $4}'))
+            grep -E "\.(tar|xbstream)\.gz$" | sort -r | awk '{print $4}'))
 
         local total=${#s3_backups[@]}
         verbose_log "Found ${total} ${backup_type} backups in S3"
@@ -252,7 +252,7 @@ cleanup_s3_with_rclone() {
         log_info "Cleaning up S3 ${backup_type} backups (keep last ${retention_count})"
 
         # List all backups
-        local s3_backups=($(rclone lsf "$remote_path" 2>/dev/null | grep "\.tar\.gz$" | sort -r))
+        local s3_backups=($(rclone lsf "$remote_path" 2>/dev/null | grep -E "\.(tar|xbstream)\.gz$" | sort -r))
 
         local total=${#s3_backups[@]}
         verbose_log "Found ${total} ${backup_type} backups in S3"
@@ -336,7 +336,7 @@ cleanup_gcs_with_gsutil() {
 
         # List all backups in GCS for this type
         local gcs_backups=($(gsutil ls "$gcs_prefix" 2>/dev/null | \
-            grep "\.tar\.gz$" | sort -r | xargs -n1 basename))
+            grep -E "\.(tar|xbstream)\.gz$" | sort -r | xargs -n1 basename))
 
         local total=${#gcs_backups[@]}
         verbose_log "Found ${total} ${backup_type} backups in GCS"
@@ -390,7 +390,7 @@ cleanup_gcs_with_rclone() {
         log_info "Cleaning up GCS ${backup_type} backups (keep last ${retention_count})"
 
         # List all backups
-        local gcs_backups=($(rclone lsf "$remote_path" 2>/dev/null | grep "\.tar\.gz$" | sort -r))
+        local gcs_backups=($(rclone lsf "$remote_path" 2>/dev/null | grep -E "\.(tar|xbstream)\.gz$" | sort -r))
 
         local total=${#gcs_backups[@]}
         verbose_log "Found ${total} ${backup_type} backups in GCS"
@@ -468,7 +468,7 @@ cleanup_r2_with_aws_cli() {
 
         # List all backups in R2 for this type
         local r2_backups=($(aws s3 ls "s3://${R2_BUCKET}/${r2_prefix}" --endpoint-url "${r2_endpoint}" 2>/dev/null | \
-            grep "\.tar\.gz$" | sort -r | awk '{print $4}'))
+            grep -E "\.(tar|xbstream)\.gz$" | sort -r | awk '{print $4}'))
 
         local total=${#r2_backups[@]}
         verbose_log "Found ${total} ${backup_type} backups in R2"
@@ -522,7 +522,7 @@ cleanup_r2_with_rclone() {
         log_info "Cleaning up R2 ${backup_type} backups (keep last ${retention_count})"
 
         # List all backups
-        local r2_backups=($(rclone lsf "$remote_path" 2>/dev/null | grep "\.tar\.gz$" | sort -r))
+        local r2_backups=($(rclone lsf "$remote_path" 2>/dev/null | grep -E "\.(tar|xbstream)\.gz$" | sort -r))
 
         local total=${#r2_backups[@]}
         verbose_log "Found ${total} ${backup_type} backups in R2"
@@ -586,7 +586,7 @@ show_statistics() {
         local dir="${!dir_var}"
 
         if [ -d "$dir" ]; then
-            local count=$(find "$dir" -maxdepth 1 -name "*.tar.gz" -type f | wc -l)
+            local count=$(find "$dir" -maxdepth 1 \( -name "*.tar.gz" -o -name "*.xbstream.gz" \) -type f | wc -l)
             local total_size=$(du -sh "$dir" 2>/dev/null | cut -f1 || echo "0")
             log_info "$(capitalize "$backup_type") backups: ${count} (${total_size})"
         fi

--- a/bin/octeth-restore.sh
+++ b/bin/octeth-restore.sh
@@ -112,7 +112,7 @@ list_local_backups() {
         local backups=()
         while IFS= read -r -d '' file; do
             backups+=("$file")
-        done < <(find "$dir" -maxdepth 1 -name "*.tar.gz" -type f -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | tr '\n' '\0')
+        done < <(find "$dir" -maxdepth 1 \( -name "*.tar.gz" -o -name "*.xbstream.gz" \) -type f -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | tr '\n' '\0')
 
         if [ ${#backups[@]} -gt 0 ]; then
             echo ""
@@ -196,7 +196,7 @@ list_s3_with_aws_cli() {
         echo "----------------------------------------"
 
         aws s3 ls "s3://${S3_BUCKET}/${s3_prefix}" --region "${S3_REGION}" 2>/dev/null | \
-            grep "\.tar\.gz$" | sort -r | \
+            grep -E "\.(tar|xbstream)\.gz$" | sort -r | \
             awk '{printf "  %-50s  %8s %s  %s %s\n", $4, $3, $2, $1, $2}'
     done
 }
@@ -214,7 +214,7 @@ list_s3_with_rclone() {
         echo "$(capitalize "$backup_type") Backups (S3):"
         echo "----------------------------------------"
 
-        rclone lsl "$remote_path" 2>/dev/null | grep "\.tar\.gz$" | sort -r
+        rclone lsl "$remote_path" 2>/dev/null | grep -E "\.(tar|xbstream)\.gz$" | sort -r
     done
 }
 
@@ -265,7 +265,7 @@ list_gcs_with_gsutil() {
         echo "----------------------------------------"
 
         gsutil ls -l "$gcs_prefix" 2>/dev/null | \
-            grep "\.tar\.gz$" | sort -r | \
+            grep -E "\.(tar|xbstream)\.gz$" | sort -r | \
             awk '{printf "  %-50s  %8s  %s %s\n", $3, $1, $2, ""}'
     done
 }
@@ -283,7 +283,7 @@ list_gcs_with_rclone() {
         echo "$(capitalize "$backup_type") Backups (GCS):"
         echo "----------------------------------------"
 
-        rclone lsl "$remote_path" 2>/dev/null | grep "\.tar\.gz$" | sort -r
+        rclone lsl "$remote_path" 2>/dev/null | grep -E "\.(tar|xbstream)\.gz$" | sort -r
     done
 }
 
@@ -328,7 +328,7 @@ list_r2_with_aws_cli() {
         echo "----------------------------------------"
 
         aws s3 ls "s3://${R2_BUCKET}/${r2_prefix}" --endpoint-url "${r2_endpoint}" 2>/dev/null | \
-            grep "\.tar\.gz$" | sort -r | \
+            grep -E "\.(tar|xbstream)\.gz$" | sort -r | \
             awk '{printf "  %-50s  %8s %s  %s %s\n", $4, $3, $2, $1, $2}'
     done
 }
@@ -346,7 +346,7 @@ list_r2_with_rclone() {
         echo "$(capitalize "$backup_type") Backups (R2):"
         echo "----------------------------------------"
 
-        rclone lsl "$remote_path" 2>/dev/null | grep "\.tar\.gz$" | sort -r
+        rclone lsl "$remote_path" 2>/dev/null | grep -E "\.(tar|xbstream)\.gz$" | sort -r
     done
 }
 
@@ -640,25 +640,78 @@ perform_restore() {
         fi
     fi
 
-    # Extract backup
+    # Extract backup. Two formats are supported:
+    #   *.xbstream.gz  - streamed backup (current): decompress -> xbstream -x -> prepare
+    #   *.tar.gz       - legacy backup: tar -xzf (already prepared at backup time)
     local extract_dir="${TEMP_DIR}/restore-$(date +%s)"
     mkdir -p "$extract_dir"
+    local backup_dir=""
 
-    log_info "Extracting backup..."
-    if tar -xzf "$backup_file" -C "$extract_dir"; then
-        log_success "Backup extracted to: $extract_dir"
-    else
-        log_error "Failed to extract backup"
-        exit 1
-    fi
+    case "$backup_file" in
+        *.xbstream.gz|*.xbstream)
+            if ! command -v xbstream &> /dev/null; then
+                log_error "xbstream not found (ships with Percona XtraBackup). Cannot restore xbstream backup."
+                exit 1
+            fi
 
-    # Find the backup directory inside the extracted archive
-    local backup_dir=$(find "$extract_dir" -maxdepth 1 -type d -name "${BACKUP_PREFIX}-*" | head -n1)
+            # Pick a decompressor (pigz can read gzip streams too)
+            local decomp="gzip -dc"
+            command -v pigz &> /dev/null && decomp="pigz -dc"
 
-    if [ -z "$backup_dir" ] || [ ! -d "$backup_dir" ]; then
-        log_error "Cannot find backup directory in extracted archive"
-        exit 1
-    fi
+            log_info "Extracting xbstream backup..."
+            case "$backup_file" in
+                *.gz)
+                    if ! ${decomp} "$backup_file" | xbstream -x -C "$extract_dir"; then
+                        log_error "Failed to extract xbstream backup"
+                        exit 1
+                    fi
+                    ;;
+                *)
+                    if ! xbstream -x -C "$extract_dir" < "$backup_file"; then
+                        log_error "Failed to extract xbstream backup"
+                        exit 1
+                    fi
+                    ;;
+            esac
+            log_success "Backup extracted to: $extract_dir"
+
+            # Streamed backups are not prepared at backup time; do it now so the
+            # data directory is consistent and restorable.
+            log_info "Preparing backup (applying transaction logs)..."
+            if ${XTRABACKUP_BIN} --prepare --target-dir="$extract_dir" >> "${LOG_FILE}" 2>&1; then
+                log_success "Backup prepared successfully"
+            else
+                log_error "Backup prepare failed (see ${LOG_FILE})"
+                exit 1
+            fi
+
+            # xbstream extracts the data files directly into extract_dir
+            backup_dir="$extract_dir"
+            ;;
+
+        *.tar.gz)
+            log_info "Extracting backup..."
+            if tar -xzf "$backup_file" -C "$extract_dir"; then
+                log_success "Backup extracted to: $extract_dir"
+            else
+                log_error "Failed to extract backup"
+                exit 1
+            fi
+
+            # Legacy archives wrap the (already prepared) data in a backup-name dir
+            backup_dir=$(find "$extract_dir" -maxdepth 1 -type d -name "${BACKUP_PREFIX}-*" | head -n1)
+
+            if [ -z "$backup_dir" ] || [ ! -d "$backup_dir" ]; then
+                log_error "Cannot find backup directory in extracted archive"
+                exit 1
+            fi
+            ;;
+
+        *)
+            log_error "Unknown backup format: $backup_file (expected *.xbstream.gz or *.tar.gz)"
+            exit 1
+            ;;
+    esac
 
     # Stop MySQL
     log_info "Stopping MySQL container..."

--- a/config/.env.example
+++ b/config/.env.example
@@ -31,6 +31,20 @@ MYSQL_PASSWORD=your_mysql_password_here
 # Example for Octeth: /opt/oempro/_dockerfiles/mysql/data_v8
 MYSQL_DATA_DIR=/opt/oempro/_dockerfiles/mysql/data_v8
 
+# Binary log basename on HOST (optional). Required ONLY when binary logging is
+# enabled AND the binlogs live OUTSIDE the data directory (e.g. a sibling log_v8/).
+# XtraBackup needs this to capture the binlog and its coordinates. Passed as
+# --log-bin. Leave empty if binary logging is disabled (skip-log-bin).
+# Example for Octeth: /opt/oempro/_dockerfiles/mysql/log_v8/mysql-bin
+MYSQL_LOG_BIN=
+
+# Binary log INDEX file on HOST (optional override). XtraBackup reads the binlog
+# index from a separate path that a containerized server reports as its
+# in-container location (which doesn't exist on the host). When MYSQL_LOG_BIN is
+# set this defaults to "<MYSQL_LOG_BIN>.index", which is correct in the common
+# case. Only set this if the index file isn't named <basename>.index.
+MYSQL_LOG_BIN_INDEX=
+
 # ============================================
 # ClickHouse Connection Settings
 # ============================================
@@ -91,13 +105,21 @@ CH_LOG_FILE=/var/log/octeth-ch-backup.log
 # ============================================
 
 # Local backup directory (absolute path)
-# Backups will be stored in subdirectories: daily/, weekly/, monthly/
+# Backups are written here (compressed) before upload. Subdirs: daily/, weekly/, monthly/
 BACKUP_DIR=/var/backups/octeth
 
-# Temporary directory for backup preparation
-# IMPORTANT: Must have enough space for full uncompressed database
-# Recommended: Use a subdirectory under BACKUP_DIR or same disk with sufficient space
-# Default /tmp often has limited space and will cause "No space left on device" errors
+# Keep backups on the local filesystem? (true/false) — applies to BOTH MySQL and ClickHouse.
+# false = delete the local copy immediately after a successful cloud upload, so the
+#         local disk only holds a backup transiently during the run. Use this to avoid
+#         the disk filling up. Requires CLOUD_STORAGE_PROVIDER != none; the local copy
+#         is never deleted if the upload failed.
+# true  = keep local copies and prune them by the RETENTION_* policy via cleanup.
+KEEP_LOCAL_BACKUP=true
+
+# Temporary directory used by RESTORE (extract + prepare a backup).
+# Backups themselves are now streamed/compressed on the fly, so a backup no longer
+# stages a full uncompressed copy here. Restore, however, extracts the archive here,
+# so this still needs room for the uncompressed database when restoring. Avoid /tmp.
 TEMP_DIR=/var/backups/octeth/tmp
 
 # Maximum local disk usage threshold (percentage)
@@ -258,7 +280,9 @@ WEBHOOK_URL=https://hooks.example.com/backup-status
 PARALLEL_THREADS=auto
 
 # Verify backup after creation (true/false)
-# This performs a prepare step to ensure backup is restorable
+# Streamed MySQL backups can't be prepared in place, so the prepare/apply-logs step
+# now runs at RESTORE time. When true, this instead runs an integrity check on the
+# compressed archive (detects truncated/corrupt output) before finishing.
 VERIFY_BACKUP=true
 
 # Lock file location (prevents concurrent backups)

--- a/config/backup.conf.example
+++ b/config/backup.conf.example
@@ -142,5 +142,7 @@ MONTHLY_DAY=1
 EMAIL_SUBJECT_SUCCESS="[SUCCESS] Octeth Backup Completed"
 EMAIL_SUBJECT_FAILURE="[FAILURE] Octeth Backup Failed"
 
-WEBHOOK_PAYLOAD_SUCCESS='{"status":"success","message":"Octeth backup completed","timestamp":"%TIMESTAMP%","backup_size":"%SIZE%"}'
-WEBHOOK_PAYLOAD_FAILURE='{"status":"failure","message":"Octeth backup failed","timestamp":"%TIMESTAMP%","error":"%ERROR%"}'
+# The "text" field makes these payloads accepted by Slack incoming webhooks
+# (which reject payloads without it); other webhook consumers ignore extra fields.
+WEBHOOK_PAYLOAD_SUCCESS='{"text":"✅ Octeth backup completed (%SIZE%) at %TIMESTAMP%","status":"success","backup_size":"%SIZE%","timestamp":"%TIMESTAMP%"}'
+WEBHOOK_PAYLOAD_FAILURE='{"text":"🚨 Octeth backup FAILED at %TIMESTAMP%: %ERROR%","status":"failure","error":"%ERROR%","timestamp":"%TIMESTAMP%"}'

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+#
+# deploy.sh - Deploy octeth-backup-tools to a server via rsync
+#
+# Uploads the project with rsync's delta transfer (only changed files / changed
+# blocks are sent) and keeps a timestamped backup of every file it overwrites or
+# deletes on the server (rsync --backup), so any deploy can be rolled back.
+#
+# NOTE: This intentionally does NOT use rsync --append. --append only works for
+# files that grow (e.g. logs); for source code it would corrupt files when their
+# contents change in place. Default delta transfer is what "upload only changed
+# files" actually means. Use --partial (below) if you need resumable transfers.
+#
+# By default the live secret config (config/.env, config/backup.conf) is NOT
+# deployed, so the server's credentials are never clobbered. Use --include-env
+# to push them for a one-off (the old versions are saved to the backup dir).
+#
+
+set -euo pipefail
+
+# ============================================
+# Defaults (override via environment or flags)
+# ============================================
+
+DEPLOY_USER="${DEPLOY_USER:-root}"
+DEPLOY_HOST="${DEPLOY_HOST:-}"
+DEPLOY_PATH="${DEPLOY_PATH:-/opt/octeth-backup-tools}"
+SSH_PORT="${SSH_PORT:-22}"
+
+DRY_RUN=false
+INCLUDE_ENV=false
+DELETE=false
+PARTIAL=false
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ============================================
+# Usage
+# ============================================
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") --host HOST [OPTIONS]
+
+Deploy octeth-backup-tools to a server with rsync (delta transfer + backups).
+
+OPTIONS:
+    -H, --host HOST       Target SSH host (required; or set DEPLOY_HOST)
+    -u, --user USER       SSH user (default: ${DEPLOY_USER})
+    -p, --path PATH       Remote install path (default: ${DEPLOY_PATH})
+    -P, --port PORT       SSH port (default: ${SSH_PORT})
+    -n, --dry-run         Show what would change without uploading (recommended first)
+        --include-env     Also deploy config/.env and config/backup.conf (overwrites server secrets)
+        --delete          Remove server files that no longer exist locally (off by default)
+        --partial         Keep partially transferred files (resumable over flaky links)
+    -h, --help            Show this help
+
+ENVIRONMENT:
+    DEPLOY_HOST, DEPLOY_USER, DEPLOY_PATH, SSH_PORT
+
+EXAMPLES:
+    # Preview a deploy (no changes made)
+    DEPLOY_HOST=my-server $(basename "$0") --dry-run
+
+    # Deploy code (leaves server config/.env untouched)
+    $(basename "$0") --host my-server
+
+    # One-off: also push the local config/.env to the server
+    $(basename "$0") --host my-server --include-env
+EOF
+    exit "${1:-0}"
+}
+
+# ============================================
+# Argument parsing
+# ============================================
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -H|--host)        DEPLOY_HOST="$2"; shift 2 ;;
+        -u|--user)        DEPLOY_USER="$2"; shift 2 ;;
+        -p|--path)        DEPLOY_PATH="$2"; shift 2 ;;
+        -P|--port)        SSH_PORT="$2"; shift 2 ;;
+        -n|--dry-run)     DRY_RUN=true; shift ;;
+        --include-env)    INCLUDE_ENV=true; shift ;;
+        --delete)         DELETE=true; shift ;;
+        --partial)        PARTIAL=true; shift ;;
+        -h|--help)        usage 0 ;;
+        *) echo "Unknown option: $1" >&2; usage 1 ;;
+    esac
+done
+
+if [ -z "$DEPLOY_HOST" ]; then
+    echo "ERROR: target host not set. Use --host or set DEPLOY_HOST." >&2
+    usage 1
+fi
+
+if ! command -v rsync &> /dev/null; then
+    echo "ERROR: rsync is not installed locally." >&2
+    exit 1
+fi
+
+# Normalise (strip any trailing slash) and derive the server-side backup dir
+DEPLOY_PATH="${DEPLOY_PATH%/}"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+BACKUP_DIR="${DEPLOY_PATH}.backups/${TIMESTAMP}"
+
+# ============================================
+# Build rsync options
+# ============================================
+
+RSYNC_OPTS=(
+    -a                       # archive: preserve perms, times, symlinks, etc.
+    --human-readable
+    --itemize-changes        # print exactly which files change
+    --compress               # compress data in transit
+    --backup                 # keep a copy of every replaced/deleted file...
+    --backup-dir="$BACKUP_DIR"  # ...in a timestamped dir OUTSIDE the deploy tree
+    # Never deploy local-only / runtime / VCS clutter:
+    --exclude='.git/'
+    --exclude='.github/'
+    --exclude='.gitignore'
+    --exclude='.DS_Store'
+    --exclude='.claude/'
+    --exclude='logs/'
+    --exclude='*.log'
+    --exclude='*.lock'
+    --exclude='*.tmp'
+    --exclude='xtrabackup_backupfiles/'
+)
+
+# Protect the server's live secret config unless explicitly overridden
+if [ "$INCLUDE_ENV" = false ]; then
+    RSYNC_OPTS+=(--exclude='config/.env' --exclude='config/backup.conf')
+fi
+
+[ "$DRY_RUN" = true ] && RSYNC_OPTS+=(--dry-run)
+[ "$DELETE" = true ]  && RSYNC_OPTS+=(--delete)
+[ "$PARTIAL" = true ] && RSYNC_OPTS+=(--partial)
+
+# ============================================
+# Deploy
+# ============================================
+
+echo "=========================================="
+echo "Deploying octeth-backup-tools"
+echo "  From:   ${SCRIPT_DIR}/"
+echo "  To:     ${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/ (port ${SSH_PORT})"
+echo "  Backup: ${BACKUP_DIR}/ (on server)"
+echo "  Mode:   $([ "$DRY_RUN" = true ] && echo 'DRY RUN' || echo 'LIVE')"
+echo "  Config: $([ "$INCLUDE_ENV" = true ] && echo 'INCLUDING config/.env + backup.conf' || echo 'excluding live config/.env + backup.conf')"
+echo "=========================================="
+
+rsync "${RSYNC_OPTS[@]}" \
+    -e "ssh -p ${SSH_PORT}" \
+    "${SCRIPT_DIR}/" \
+    "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/"
+
+if [ "$DRY_RUN" = true ]; then
+    echo ""
+    echo "Dry run complete. Re-run without --dry-run to deploy."
+    exit 0
+fi
+
+# Make sure the scripts are executable on the server
+echo ""
+echo "Setting executable permissions on server scripts..."
+ssh -p "${SSH_PORT}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
+    "chmod +x '${DEPLOY_PATH}'/bin/*.sh '${DEPLOY_PATH}'/*.sh 2>/dev/null || true"
+
+echo ""
+echo "Deploy complete."
+echo "Replaced files (if any) were backed up to: ${BACKUP_DIR}/ on the server."

--- a/install.sh
+++ b/install.sh
@@ -32,19 +32,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # ============================================
 
 log_info() {
-    echo -e "${BLUE}[INFO]${NC} $@"
+    echo -e "${BLUE}[INFO]${NC} $*"
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${NC} $@"
+    echo -e "${GREEN}[SUCCESS]${NC} $*"
 }
 
 log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $@"
+    echo -e "${YELLOW}[WARN]${NC} $*"
 }
 
 log_error() {
-    echo -e "${RED}[ERROR]${NC} $@"
+    echo -e "${RED}[ERROR]${NC} $*"
 }
 
 # ============================================
@@ -267,23 +267,38 @@ check_aws_cli() {
 }
 
 install_aws_cli() {
-    log_info "Installing AWS CLI..."
+    log_info "Installing AWS CLI v2 (official installer)..."
 
-    if command -v pip3 &> /dev/null; then
-        sudo pip3 install awscli
-    elif command -v pip &> /dev/null; then
-        sudo pip install awscli
-    else
-        log_warn "pip not found, using package manager..."
-        local pkg_mgr=$(detect_package_manager)
+    local pkg_mgr=$(detect_package_manager)
+    local arch=$(uname -m)   # x86_64 or aarch64 — matches AWS download naming
 
+    # The v2 installer needs curl + unzip
+    if ! command -v unzip &> /dev/null; then
+        log_info "Installing unzip (required for the AWS CLI v2 installer)..."
         case "$pkg_mgr" in
-            apt)
-                sudo apt-get install -y awscli
-                ;;
-            yum|dnf)
-                sudo $pkg_mgr install -y awscli
-                ;;
+            apt) sudo apt-get install -y unzip ;;
+            yum|dnf) sudo "$pkg_mgr" install -y unzip ;;
+        esac
+    fi
+
+    if command -v curl &> /dev/null && command -v unzip &> /dev/null; then
+        local tmp
+        tmp=$(mktemp -d)
+        if curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${arch}.zip" -o "${tmp}/awscliv2.zip" \
+            && unzip -q "${tmp}/awscliv2.zip" -d "${tmp}"; then
+            sudo "${tmp}/aws/install" --update
+        else
+            log_warn "AWS CLI v2 download/extract failed"
+        fi
+        rm -rf "${tmp}"
+    fi
+
+    # Fall back to the distro package if v2 didn't land
+    if ! check_aws_cli; then
+        log_warn "Falling back to the distribution AWS CLI package"
+        case "$pkg_mgr" in
+            apt) sudo apt-get install -y awscli ;;
+            yum|dnf) sudo "$pkg_mgr" install -y awscli ;;
             *)
                 log_error "Cannot install AWS CLI automatically"
                 log_error "Please install manually: https://aws.amazon.com/cli/"
@@ -294,6 +309,9 @@ install_aws_cli() {
 
     if check_aws_cli; then
         log_success "AWS CLI installed successfully"
+    else
+        log_error "AWS CLI installation failed"
+        return 1
     fi
 }
 
@@ -568,6 +586,11 @@ run_config_wizard() {
         cp "${SCRIPT_DIR}/config/.env.example" "$env_file"
     fi
 
+    # The storage test (offered below) sources backup.conf, so make sure it exists
+    if [ ! -f "${SCRIPT_DIR}/config/backup.conf" ]; then
+        cp "${SCRIPT_DIR}/config/backup.conf.example" "${SCRIPT_DIR}/config/backup.conf"
+    fi
+
     # MySQL settings
     if [ "$ENABLE_MYSQL" = true ]; then
         echo ""
@@ -589,6 +612,14 @@ run_config_wizard() {
         read -p "MySQL data directory on host [/opt/oempro/_dockerfiles/mysql/data_v8]: " mysql_data_dir
         mysql_data_dir=${mysql_data_dir:-/opt/oempro/_dockerfiles/mysql/data_v8}
         sed -i "s|^MYSQL_DATA_DIR=.*|MYSQL_DATA_DIR=$mysql_data_dir|" "$env_file"
+
+        echo ""
+        log_info "Binary logs: only needed if binary logging is enabled AND the binlogs"
+        log_info "live OUTSIDE the data directory (e.g. a sibling log_v8/). Leave empty otherwise."
+        read -p "MySQL binary log basename on host (optional) []: " mysql_log_bin
+        if [ -n "$mysql_log_bin" ]; then
+            sed -i "s|^MYSQL_LOG_BIN=.*|MYSQL_LOG_BIN=$mysql_log_bin|" "$env_file"
+        fi
     fi
 
     # ClickHouse settings
@@ -677,10 +708,31 @@ run_config_wizard() {
                 sed -i "s|^R2_SECRET_ACCESS_KEY=.*|R2_SECRET_ACCESS_KEY=$r2_secret_key|" "$env_file"
                 ;;
         esac
+
+        # No-local retention: delete the local copy after a successful upload
+        echo ""
+        log_info "No-local mode deletes the local backup right after a successful cloud"
+        log_info "upload (so the disk only holds it transiently). Recommended for large DBs."
+        read -p "Delete local backups after upload (KEEP_LOCAL_BACKUP=false)? (y/n) [n]: " no_local
+        if [ "$no_local" = "y" ] || [ "$no_local" = "Y" ]; then
+            sed -i "s/^KEEP_LOCAL_BACKUP=.*/KEEP_LOCAL_BACKUP=false/" "$env_file"
+            log_info "Set KEEP_LOCAL_BACKUP=false (local copies removed after upload)"
+        fi
     fi
 
     echo ""
     log_success "Configuration saved to $env_file"
+
+    # Offer to validate cloud connectivity now (write/read/delete cycle)
+    if [ "${enable_cloud:-n}" = "y" ] || [ "${enable_cloud:-n}" = "Y" ]; then
+        echo ""
+        read -p "Test cloud storage connectivity now? (y/n) [y]: " test_storage
+        test_storage=${test_storage:-y}
+        if [ "$test_storage" = "y" ] || [ "$test_storage" = "Y" ]; then
+            "${SCRIPT_DIR}/bin/octeth-test-storage.sh" -v || \
+                log_warn "Storage test reported issues — review the output above before relying on backups"
+        fi
+    fi
 }
 
 # ============================================


### PR DESCRIPTION
Brings the production-proven improvements (developed and validated on the lindris and upsender deployments) into the canonical tool, for **both** the MySQL and ClickHouse engines.

## MySQL (`octeth-backup.sh`, `octeth-restore.sh`, `octeth-cleanup.sh`)
- **Streaming backups**: `xtrabackup --backup --stream=xbstream | <compressor> > …xbstream.gz` — written to disk once, already compressed. No uncompressed temp staging, no separate tar pass. Preserves the existing host-network / exposed-port / container-IP connection detection.
- **`--log-bin` / `--log-bin-index`**: capture binlogs that live outside the data directory (auto-derives the index path). Empty by default; needed where the lindris-style `log_v8/` layout caused `cannot open binlog index file`.
- **`VERIFY_BACKUP`** → cheap compressed-archive integrity check; the prepare/apply-logs step moved to **restore** time.
- **Restore** reads both `.xbstream.gz` (decompress → `xbstream -x` → `--prepare`) and legacy `.tar.gz`. Cleanup + restore match both formats.
- `check_disk_space` validates `BACKUP_DIR` (~40%-of-DB estimate) instead of requiring a full uncompressed copy in `TEMP_DIR`.

## ClickHouse (`octeth-ch-backup.sh`)
- **tar-direct**: archive straight from the `clickhouse-backup` output dir (host volume or `docker exec tar`) into the compressor — removes the extra full copy into `CH_TEMP_DIR`.
- Same disk-check relaxation.

## Both engines
- **`KEEP_LOCAL_BACKUP=false`** deletes the local copy after a successful cloud upload (so the disk doesn't fill). **Safety invariant**: `upload_to_{s3,gcs,r2}` now return non-zero if the *data* upload fails (checksum upload is best-effort), so the last copy is never deleted on a failed upload.
- Slack-compatible webhook payloads (added a `text` field).

## Repo
- New `deploy.sh` (rsync delta deploy; saves overwritten files to a timestamped dir on the server; excludes live config by default).
- `config/.env.example` + `backup.conf.example`: `KEEP_LOCAL_BACKUP`, `MYSQL_LOG_BIN`, `MYSQL_LOG_BIN_INDEX`, refreshed comments.
- README + CLAUDE.md updated.

## Config / migration notes
- New keys are safe-defaulted (`KEEP_LOCAL_BACKUP` defaults to `true` = current behavior; `MYSQL_LOG_BIN` empty = off), so existing `.env` files keep working unchanged. Deployments that want no-local set `KEEP_LOCAL_BACKUP=false` on the server.
- **Backup artifact format changes** for MySQL (`.tar.gz` → `.xbstream.gz`); restore stays backward-compatible with existing `.tar.gz` backups.

## Verification
- `bash -n` passes on all 8 scripts; `shellcheck -S error` clean on all changed files (the 2 remaining errors are pre-existing in the untouched `octeth-test-storage.sh`).
- Not exercised against a live DB in this change — the streaming + binlog paths were validated by real backups on the lindris (MySQL, 272 GB) and upsender deployments. Recommend a staging backup + restore before rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)